### PR TITLE
Bump appservice-build To v2

### DIFF
--- a/.github/workflows/master_physaci.yml
+++ b/.github/workflows/master_physaci.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: '3.7'
 
     - name: Build using AppService-Build
-      uses: azure/appservice-build@v1
+      uses: azure/appservice-build@v2
       with:
         platform: python
 


### PR DESCRIPTION
Hopefully it fixes the Oryx build issue. A silent failure on deployment, ofc. Deployment is listed as successful, but results in this:
```
2020-05-30T22:58:35.338731988Z Updated PYTHONPATH to ':/home/site/wwwroot/pythonenv3.8/lib/python3.7/site-packages'
2020-05-30T22:58:36.922202091Z [2020-05-30 22:58:36 +0000] [38] [INFO] Starting gunicorn 20.0.4
2020-05-30T22:58:36.940369333Z [2020-05-30 22:58:36 +0000] [41] [INFO] Booting worker with pid: 41
2020-05-30T22:58:36.969330975Z [2020-05-30 22:58:36 +0000] [41] [ERROR] Exception in worker process
2020-05-30T22:58:36.969350975Z Traceback (most recent call last):
2020-05-30T22:58:36.969356776Z   File "/opt/python/3.7.5/lib/python3.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
[....]
2020-05-30T22:58:36.969472081Z     import requests
2020-05-30T22:58:36.969476181Z ModuleNotFoundError: No module named 'requests
```